### PR TITLE
Minor fixes to support the latest changes in Xray Cloud

### DIFF
--- a/src/pytest_xray/xray_publisher.py
+++ b/src/pytest_xray/xray_publisher.py
@@ -114,5 +114,5 @@ class XrayPublisher:
         :return: test execution issue id
         """
         response_data = self._send_data(self.endpoint_url, self.auth, data)
-        key = response_data['testExecIssue']['key']
+        key = response_data['key']
         return key

--- a/src/pytest_xray/xray_publisher.py
+++ b/src/pytest_xray/xray_publisher.py
@@ -45,7 +45,7 @@ class BearerAuth(AuthBase):
             _logger.exception(err_message)
             raise XrayError(err_message) from exc
         else:
-            auth_token = response.text
+            auth_token = response.text.replace('"', '')
             r.headers['Authorization'] = f'Bearer {auth_token}'
         return r
 

--- a/src/pytest_xray/xray_publisher.py
+++ b/src/pytest_xray/xray_publisher.py
@@ -12,6 +12,7 @@ _logger = logging.getLogger(__name__)
 
 
 class BearerAuth(AuthBase):
+
     def __init__(self, base_url: str, client_id: str, client_secret: str) -> None:
         if base_url.endswith('/'):
             base_url = base_url[:-1]
@@ -24,11 +25,21 @@ class BearerAuth(AuthBase):
         return f'{self.base_url}{AUTHENTICATE_ENDPOINT}'
 
     def __call__(self, r: requests.PreparedRequest) -> requests.PreparedRequest:
-        headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-        auth_data = {'client_id': self.client_id, 'client_secret': self.client_secret}
+        headers = {
+            'Content-type': 'application/json',
+            'Accept': 'text/plain'
+        }
+        auth_data = {
+            'client_id': self.client_id,
+            'client_secret': self.client_secret
+        }
 
         try:
-            response = requests.post(self.endpoint_url, data=json.dumps(auth_data), headers=headers)
+            response = requests.post(
+                self.endpoint_url,
+                data=json.dumps(auth_data),
+                headers=headers
+            )
         except requests.exceptions.ConnectionError as exc:
             err_message = f'ConnectionError: cannot authenticate with {self.endpoint_url}'
             _logger.exception(err_message)
@@ -40,6 +51,7 @@ class BearerAuth(AuthBase):
 
 
 class ApiKeyAuth(AuthBase):
+
     def __init__(self, api_key: str) -> None:
         self.api_key = api_key
 
@@ -49,8 +61,13 @@ class ApiKeyAuth(AuthBase):
 
 
 class XrayPublisher:
+
     def __init__(
-        self, base_url: str, endpoint: str, auth: Union[AuthBase, tuple], verify: Union[bool, str] = True
+        self,
+        base_url: str,
+        endpoint: str,
+        auth: Union[AuthBase, tuple],
+        verify: Union[bool, str] = True
     ) -> None:
         if base_url.endswith('/'):
             base_url = base_url[:-1]
@@ -64,10 +81,14 @@ class XrayPublisher:
         return self.base_url + self.endpoint
 
     def _send_data(self, url: str, auth: Union[AuthBase, tuple], data: dict) -> dict:
-        headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+        headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
         try:
             response = requests.request(
-                method='POST', url=url, headers=headers, json=data, auth=auth, verify=self.verify
+                method='POST', url=url, headers=headers, json=data,
+                auth=auth, verify=self.verify
             )
         except requests.exceptions.ConnectionError as exc:
             err_message = f'ConnectionError: cannot connect to JIRA service at {url}'
@@ -77,10 +98,8 @@ class XrayPublisher:
             try:
                 response.raise_for_status()
             except requests.exceptions.HTTPError as exc:
-                err_message = (
-                    f'HTTPError: Could not post to JIRA service at {url}. '
-                    f'Response status code: {response.status_code}'
-                )
+                err_message = (f'HTTPError: Could not post to JIRA service at {url}. '
+                               f'Response status code: {response.status_code}')
                 _logger.exception(err_message)
                 if 'error' in response.json():
                     _logger.error('Error message from server: %s', response.json()['error'])
@@ -95,5 +114,6 @@ class XrayPublisher:
         :return: test execution issue id
         """
         response_data = self._send_data(self.endpoint_url, self.auth, data)
+        # The Xray cloud response does not include the 'testExecIssue' attribute
         key = response_data['testExecIssue']['key'] if 'testExecIssue' in response_data else response_data['key']
         return key

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def http_server(environment_variables):
     # cloud
     server.add_json_response(
         '/api/v2/import/execution',
-        {'testExecIssue': {'key': '1000'}},
+        {'key': '1000'},
         methods=('POST',)
     )
     server.add_callback_response(


### PR DESCRIPTION
There appear to be some changes in Xray cloud that have caused some problems for this plugin. I made some minor fixes to adapt to these changes.

1. The authentication token is returned by the API authenticate endpoint as a quoted string. The quotes are now stripped out before the token is used.
2. The response from the import execution API call does not include the `testExecIssue{"key": "..."}` parameter. Instead, the `key` parameter is stored at the top level in the JSON response.
3. Updated the tests for the new behavior.