### PR TITLE
Updating Xray testcase test steps when using duplicate test IDs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,8 @@ Mark a test with JIRA XRAY test ID or list of IDs
         assert True
 
     @pytest.mark.xray(['JIRA-2', 'JIRA-3'])
-        def test_bar():
-            assert True
+    def test_bar():
+        assert True
 
 
 Jira Xray configuration can be provided via Environment Variables:
@@ -200,6 +200,26 @@ the following rules:
 - The comment will be the comment from each of the test, separated by a horizontal divider.
 - The status will be the intuitive combination of the individual results: if ``test_my_process_1`` 
   is a ``PASS`` but ``test_my_process_2`` is a ``FAIL``, ``JIRA-1`` will be marked as ``FAIL``.
+
+You can also mark multiple steps for a single Xray testcase using duplicate test ids and the ``step=``
+option:
+    .. code-block:: python
+
+        # -- FILE: test_example.py
+        import pytest
+
+        @pytest.mark.xray('JIRA-1', step=1)
+        def test_foo():
+            assert True
+
+        @pytest.mark.xray('JIRA-1', step=2)
+        def test_bar():
+            assert True
+            
+In this case, the Pass/Fail result of the marked test method will become a PASS/FAIL 
+for the associated Xray test step. Additionally, the comment for each test method will become a
+comment in the Xray test step. The overall Xray testcase status will be marked as FAIL if any test
+steps fail.
 
 
 IntelliJ integration

--- a/src/pytest_xray/helper.py
+++ b/src/pytest_xray/helper.py
@@ -66,9 +66,9 @@ class TestCase:
         if status_str_mapper is None:
             status_str_mapper = STATUS_STR_MAPPER_JIRA
         self.status_str_mapper = status_str_mapper
-        
+
         if test_step is not None:
-            self.steps.append({"index": test_step, "data":{"status": status, "comment": self.comment}})
+            self.steps.append({"index": test_step, "data": {"status": status, "comment": self.comment}})
             self.comment = ''
 
     def merge(self, other: 'TestCase'):
@@ -109,7 +109,7 @@ class TestCase:
         if self.steps:
             # Format our steps into the correct format for the Xray API
             last_step = max(self.steps, key=lambda s: s["index"])
-            steps_len =  last_step["index"] + 1
+            steps_len = last_step["index"] + 1
 
             # Build a list up to max_index size, and set every status to "TODO"
             fmt_steps = [{"status": self.status_str_mapper[Status.TODO]} for _ in range(steps_len)]
@@ -119,6 +119,8 @@ class TestCase:
                 step["data"]["status"] = self.status_str_mapper[step["data"]["status"]]
                 fmt_steps[step["index"]] = step["data"]
         return fmt_steps
+
+
 class TestExecution:
 
     def __init__(

--- a/src/pytest_xray/plugin.py
+++ b/src/pytest_xray/plugin.py
@@ -143,7 +143,7 @@ class XrayPlugin:
         logfile = self.config.getoption(XRAYPATH)
         self.logfile: str = self._get_normalize_logfile(logfile) if logfile else None
         self.test_keys: Dict[str, List[str]] = {}  # store nodeid and TestId
-        self.test_steps: Dict[str, int] = {} # store nodeid and test step
+        self.test_steps: Dict[str, int] = {}  # store nodeid and test step
         self.issue_id = None
         self.exception = None
         self.test_execution: TestExecution = TestExecution(
@@ -183,7 +183,7 @@ class XrayPlugin:
             if "step" in marker.kwargs:
                 if isinstance(marker.kwargs["step"], int):
                     # Steps in jira are 1-based, but the report that is sent to
-                    # Xray is 0 based. One is subtracted here to make that 
+                    # Xray is 0 based. One is subtracted here to make that
                     # conversion
                     test_step = marker.kwargs["step"] - 1
                 else:
@@ -197,7 +197,6 @@ class XrayPlugin:
 
             self.test_keys[item.nodeid] = test_keys
             self.test_steps[item.nodeid] = test_step
-        
 
             if duplicated_jira_ids and not self.allow_duplicate_ids:
                 raise XrayError(f'Duplicated test case ids: {duplicated_jira_ids}')

--- a/src/pytest_xray/plugin.py
+++ b/src/pytest_xray/plugin.py
@@ -143,6 +143,7 @@ class XrayPlugin:
         logfile = self.config.getoption(XRAYPATH)
         self.logfile: str = self._get_normalize_logfile(logfile) if logfile else None
         self.test_keys: Dict[str, List[str]] = {}  # store nodeid and TestId
+        self.test_steps: Dict[str, int] = {} # store nodeid and test step
         self.issue_id = None
         self.exception = None
         self.test_execution: TestExecution = TestExecution(
@@ -170,12 +171,23 @@ class XrayPlugin:
                 continue
 
             test_keys: List[str]
+            test_step: int = None
             if isinstance(marker.args[0], str):
                 test_keys = [marker.args[0]]
             elif isinstance(marker.args[0], list):
                 test_keys = list(marker.args[0])
             else:
-                raise XrayError("xray marker can only accept strings or lists")
+                raise XrayError("xray test key can only be a string or lists")
+
+            # Collect test steps, but they're only used for duplicated test ids
+            if "step" in marker.kwargs:
+                if isinstance(marker.kwargs["step"], int):
+                    # Steps in jira are 1-based, but the report that is sent to
+                    # Xray is 0 based. One is subtracted here to make that 
+                    # conversion
+                    test_step = marker.kwargs["step"] - 1
+                else:
+                    raise XrayError("xray test step can only be an integer")
 
             for test_key in test_keys:
                 if test_key in jira_ids:
@@ -184,6 +196,8 @@ class XrayPlugin:
                     jira_ids.append(test_key)
 
             self.test_keys[item.nodeid] = test_keys
+            self.test_steps[item.nodeid] = test_step
+        
 
             if duplicated_jira_ids and not self.allow_duplicate_ids:
                 raise XrayError(f'Duplicated test case ids: {duplicated_jira_ids}')
@@ -191,6 +205,9 @@ class XrayPlugin:
     def _get_test_keys_for(self, nodeid: str) -> Optional[List[str]]:
         """Return XRAY test id for nodeid."""
         return self.test_keys.get(nodeid)
+
+    def _get_test_step_for(self, nodeid: str) -> Optional[int]:
+        return self.test_steps.get(nodeid)
 
     @staticmethod
     def _get_xray_marker(item: Item) -> Optional[Mark]:
@@ -205,6 +222,8 @@ class XrayPlugin:
             return
 
         test_keys = self._get_test_keys_for(report.nodeid)
+        test_step = self._get_test_step_for(report.nodeid)
+
         if test_keys is None:
             return
 
@@ -213,7 +232,8 @@ class XrayPlugin:
                 test_key=test_key,
                 status=status,
                 comment=report.longreprtext,
-                status_str_mapper=self.status_str_mapper
+                status_str_mapper=self.status_str_mapper,
+                test_step=test_step
             )
             try:
                 test_case = self.test_execution.find_test_case(test_key)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -61,7 +61,7 @@ def test_merge_test_cases():
 
     assert t1.test_key == "JIRA-1"
     assert t1.status == Status.FAIL
-    assert t1.comment == "hello\n" + "-" * 80 + "\nhi"
+    assert t1.comment == "{noformat}\nhello\n{noformat}\n" + "-" * 80 + "\n{noformat}\nhi\n{noformat}"
 
     with pytest.raises(ValueError):
         t1.merge(t3)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -12,6 +12,7 @@ from pytest_xray import constant
 def formatted_comment(comment: str):
     return f"{{noformat}}\n{comment}\n{{noformat}}"
 
+
 @pytest.fixture
 def date_time_now():
     return dt.datetime(2021, 4, 23, 16, 30, 2, 0, tzinfo=dt.timezone.utc)
@@ -25,6 +26,7 @@ def testcase():
         status='PASS'
     )
 
+
 @pytest.fixture
 def testcase_with_steps_0():
     return _TestCase(
@@ -33,6 +35,7 @@ def testcase_with_steps_0():
         status='PASS',
         test_step=0
     )
+
 
 @pytest.fixture
 def testcase_with_steps_1():
@@ -43,6 +46,7 @@ def testcase_with_steps_1():
         test_step=1
     )
 
+
 @pytest.fixture
 def testcase_with_steps_2():
     return _TestCase(
@@ -51,6 +55,7 @@ def testcase_with_steps_2():
         status='PASS',
         test_step=2
     )
+
 
 def test_testcase_output_dictionary(testcase):
     assert testcase.as_dict() == {
@@ -162,6 +167,7 @@ def test_test_execution_full_model(testcase, date_time_now):
             ]
         }
 
+
 @mock.patch.dict(os.environ, {
     constant.ENV_TEST_EXECUTION_FIX_VERSION: '1.1',
     constant.ENV_TEST_EXECUTION_TEST_ENVIRONMENTS: 'MyLocalLaptop And TheLiveSystem',
@@ -196,6 +202,7 @@ def test_test_execution_environ_model(testcase, date_time_now):
                 }
             ]
         }
+
 
 def test_test_execution_with_step(testcase_with_steps_0, date_time_now):
     with patch('datetime.datetime') as dt_mock:
@@ -232,11 +239,12 @@ def test_test_execution_with_step(testcase_with_steps_0, date_time_now):
             ]
         }
 
+
 def test_test_execution_with_multiple_steps(
-    testcase_with_steps_0, 
-    testcase_with_steps_1,
-    testcase_with_steps_2, 
-    date_time_now):
+        testcase_with_steps_0,
+        testcase_with_steps_1,
+        testcase_with_steps_2,
+        date_time_now):
     with patch('datetime.datetime') as dt_mock:
         dt_mock.now.return_value = date_time_now
         te = _TestExecution(
@@ -275,4 +283,4 @@ def test_test_execution_with_multiple_steps(
                         ]
                 },
             ]
-        }    
+        }


### PR DESCRIPTION
This feature may go against your overall vision for the project. I just wanted to offer it back to the community in case it was useful to others. If you don't wish to pull it in, it won't hurt my feelings :-)

- Added the ability to mark test methods with `step=n` to match up with the ordered test steps that are defined in an Xray Testcase. This is generally only useful for duplicated test ids, but you can also do this for single and multiple unique test ids.
- Added the `{noformat}` Jira tags to keep comments from being interpreted as macros in Jira.
- Added tests for the new feature.
- Added a new documentation blurb to show how the new feature works.