### PR TITLE
Updated X-Ray plugin to use with a custom executionEndpoint and different xray_execution_key values

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   tests:
+    needs: flake8
     runs-on: ubuntu-latest
     name: Tests
     strategy:
@@ -41,6 +42,7 @@ jobs:
         run: tox -e flake8
 
   coverage:
+    needs: tests
     runs-on: ubuntu-latest
     name: Coverage
     steps:
@@ -53,8 +55,12 @@ jobs:
         run: pip install tox
       - name: Run tests with coverage
         run: tox -e coverage
+      - name: Read DISABLE_UPLOAD_COVERAGE_REPORT variable
+        id: disable_upload_coverage_report
+        run: echo '::set-output name=value::${{secrets.DISABLE_UPLOAD_COVERAGE_REPORT}}'
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
+        if: steps.disable_upload_coverage_report.outputs.value != 'true'
         with:
           directory: ./coverage/reports/
           fail_ci_if_error: true

--- a/src/pytest_xray/helper.py
+++ b/src/pytest_xray/helper.py
@@ -180,6 +180,14 @@ class TestExecution:
         return data
 
 
+def get_endpoints() -> dict:
+    options = {}
+    options['executionEndPoint'] = environ.get('XRAY_TEST_EXECUTION_ENDPOINT') or constant.TEST_EXECUTION_ENDPOINT
+    options['executionCloudEndPoint'] = environ.get('XRAY_TEST_EXECUTION_ENDPOINT_CLOUD') \
+        or constant.TEST_EXECUTION_ENDPOINT_CLOUD
+    return options
+
+
 def get_base_options() -> Dict[str, Any]:
     options = {}
     try:


### PR DESCRIPTION
Changes:
[+] Added an ability to use arguments '**test_key**' and '**test_exec_key**' with **pytest.mark.xray**. We can use '**test_exec_key**' argument to specify an execution ticket id for each of the tests separately inside the test case.
[+] Added '**XRAY_TEST_EXECUTION_ENDPOINT**' and '**XRAY_TEST_EXECUTION_ENDPOINT_CLOUD**' environment variables to have an ability specify these values outside the code.
[+] Added '**DISABLE_UPLOAD_COVERAGE_REPORT**' environment variable into the GitHub Action to have an ability disable upload coverage report from the forks.
[+] Made order for steps in GitHub Action pipeline: flask8 -> tests -> coverage

Old functionality didn't change.
We can continiue use the old format:
`@pytest.mark.xray('JIRA-3')`
We can use a new format:
```
@pytest.mark.xray(test_key='JIRA-3')
@pytest.mark.xray(test_key='JIRA-3', test_exec_key='JIRA-1')
```