### PR TITLE
Implement hook to modify results

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,6 +230,17 @@ the following rules:
   is a ``PASS`` but ``test_my_process_2`` is a ``FAIL``, ``JIRA-1`` will be marked as ``FAIL``.
 
 
+Hooks
++++++
+
+There is possibility to modify a XRAY report before it is send to a server by ``pytest_xray_results`` hook.
+
+.. code-block:: python
+
+    def pytest_xray_results(results, session):
+        results['info']['user'] = 'pytest'
+
+
 IntelliJ integration
 ++++++++++++++++++++
 

--- a/src/pytest_xray/hooks.py
+++ b/src/pytest_xray/hooks.py
@@ -1,0 +1,12 @@
+import pytest
+from typing import Dict, Any
+
+
+@pytest.hookspec
+def pytest_xray_results(results: Dict[str, Any], session: pytest.Session) -> None:
+    """
+    Called before uploading XRAY result to Jira server.
+
+    :param results: xray results dictionary
+    :param session: pytest session
+    """

--- a/src/pytest_xray/plugin.py
+++ b/src/pytest_xray/plugin.py
@@ -39,6 +39,7 @@ from pytest_xray.helper import (
     get_api_key_auth,
     get_basic_auth, get_api_token_auth,
 )
+from pytest_xray import hooks
 from pytest_xray.xray_publisher import (
     ClientSecretAuth,
     ApiKeyAuth,
@@ -109,7 +110,6 @@ def pytest_addoption(parser: Parser):
 
 
 def pytest_addhooks(pluginmanager):
-    from pytest_xray import hooks
     pluginmanager.add_hookspecs(hooks)
 
 

--- a/tests/test_xray_plugin.py
+++ b/tests/test_xray_plugin.py
@@ -95,6 +95,19 @@ def test_jira_xray_plugin_exports_to_file(xray_tests):
     assert xray_file.exists()
 
 
+def test_if_user_can_modify_results_with_hooks(xray_tests):
+    xray_file = xray_tests.tmpdir.join('xray.json')
+    xray_tests.makeconftest("""
+        def pytest_xray_results(results):
+            results['info']['user'] = 'Test User'
+    """)
+    result = xray_tests.runpytest('--jira-xray', '--xraypath', str(xray_file))
+    assert result.ret == 0
+    xray_result = json.load(xray_file.open())
+    assert 'user' in xray_result['info']
+    assert xray_result['info']['user'] == 'Test User'
+
+
 def test_jira_xray_plugin_multiple_ids(xray_tests_multi):
     xray_file = xray_tests_multi.tmpdir.join('xray.json')
     result = xray_tests_multi.runpytest('--jira-xray', '--xraypath', str(xray_file))


### PR DESCRIPTION
Added `pytest_xray_results` hook which allows users to modify XRAY report before it is uploaded. 
