### PR TITLE
Fix sending mutiple results while running with xdist

### DIFF
--- a/src/pytest_xray/plugin.py
+++ b/src/pytest_xray/plugin.py
@@ -87,6 +87,8 @@ def pytest_configure(config: Config) -> None:
     config.addinivalue_line(
         'markers', 'xray(JIRA_ID): mark test with JIRA XRAY test case ID'
     )
+    if config.option.collectonly:
+        return
 
     if not config.getoption(JIRA_XRAY_FLAG):
         return

--- a/src/pytest_xray/xray_plugin.py
+++ b/src/pytest_xray/xray_plugin.py
@@ -153,6 +153,8 @@ class XrayPlugin:
         self._verify_jira_ids_for_items(items)
 
     def pytest_sessionfinish(self, session: pytest.Session) -> None:
+        if hasattr(self.config, 'workerinput'):  # skipping on xdist
+            return
         self.test_execution.finish_date = dt.datetime.now(tz=dt.timezone.utc)
         results = self.test_execution.as_dict()
         session.config.pluginmanager.hook.pytest_xray_results(


### PR DESCRIPTION
When xdist plugin is used Xray results is sending to the server multiple times, once for each xdist worker plus main thread.