### PR TITLE
Fix a test_help_message

### DIFF
--- a/src/pytest_xray/plugin.py
+++ b/src/pytest_xray/plugin.py
@@ -36,7 +36,7 @@ def pytest_addoption(parser: Parser):
         JIRA_CLOUD,
         action='store_true',
         default=False,
-        help='Use with JIRA XRAY could server'
+        help='Use with JIRA XRAY cloud server'
     )
     xray.addoption(
         JIRA_API_KEY,

--- a/tests/test_xray_plugin.py
+++ b/tests/test_xray_plugin.py
@@ -57,12 +57,13 @@ def test_help_message(xray_tests):
     result.stdout.fnmatch_lines([
         'Jira Xray report:',
         '*--jira-xray*Upload test results to JIRA XRAY*',
-        '*--cloud*Use with JIRA XRAY could server*',
+        '*--cloud*Use with JIRA XRAY cloud server*',
         '*--api-key-auth*Use Jira API Key authentication*',
         '*--client-secret-auth*Use client secret authentication*',
         '*--execution=ExecutionId*', '*XRAY Test Execution ID*',
         '*--testplan=TestplanId*', '*XRAY Test Plan ID*',
         '*--xraypath=path*Do not upload to a server but create JSON report file at*', '*given path*',
+        '*--allow-duplicate-ids*', '*Allow test ids to be present on multiple pytest tests*',
     ])
 
 


### PR DESCRIPTION
Hello,

I have added a test for --allow-duplicate-ids help message and I have fixed a typo in --cloud help message.

Regards,
Ronan