### PR TITLE
Fix formatting issues with pytest captures

### DIFF
--- a/src/pytest_xray/helper.py
+++ b/src/pytest_xray/helper.py
@@ -103,8 +103,9 @@ class TestCase:
         data: Dict[str, Any] = dict(
             testKey=self.test_key,
             status=self.status_str_mapper[self.status],
-            comment="{noformat:borderWidth=0px|bgColor=transparent}" + self.comment + "{noformat}",
         )
+        if self.comment != '':
+            data['comment'] = "{noformat:borderWidth=0px|bgColor=transparent}" + self.comment + "{noformat}"
         if self.evidences:
             data['evidences'] = self.evidences
         return data

--- a/src/pytest_xray/helper.py
+++ b/src/pytest_xray/helper.py
@@ -103,7 +103,7 @@ class TestCase:
         data: Dict[str, Any] = dict(
             testKey=self.test_key,
             status=self.status_str_mapper[self.status],
-            comment=self.comment,
+            comment="{noformat:borderWidth=0px|bgColor=transparent}" + self.comment + "{noformat}",
         )
         if self.evidences:
             data['evidences'] = self.evidences

--- a/src/pytest_xray/xray_plugin.py
+++ b/src/pytest_xray/xray_plugin.py
@@ -123,7 +123,8 @@ class XrayPlugin:
 
         comment = report.longreprtext
         if self.add_captures:
-            comment += '\n'
+            if comment != '':
+                comment += '\n'
             if report.capstdout:
                 comment += f"{'-'*29} Captured stdout call {'-'*29}\n{report.capstdout}"
             if report.capstderr:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -19,7 +19,7 @@ def date_time_now():
 def testcase():
     return _TestCase(
         test_key='JIRA-1',
-        comment='{noformat:borderWidth=0px|bgColor=transparent}Test{noformat}',
+        comment='Test',
         status='PASS'
     )
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -19,7 +19,7 @@ def date_time_now():
 def testcase():
     return _TestCase(
         test_key='JIRA-1',
-        comment='Test',
+        comment='{noformat:borderWidth=0px|bgColor=transparent}Test{noformat}',
         status='PASS'
     )
 
@@ -27,7 +27,7 @@ def testcase():
 def test_testcase_output_dictionary(testcase):
     assert testcase.as_dict() == {
         'testKey': 'JIRA-1',
-        'comment': 'Test',
+        'comment': '{noformat:borderWidth=0px|bgColor=transparent}Test{noformat}',
         'status': 'PASS'
     }
 
@@ -44,7 +44,7 @@ def test_test_execution_output_dictionary(testcase, date_time_now):
             },
             'tests': [
                 {
-                    'comment': 'Test',
+                    'comment': '{noformat:borderWidth=0px|bgColor=transparent}Test{noformat}',
                     'status': 'PASS',
                     'testKey': 'JIRA-1'
                 }
@@ -65,7 +65,7 @@ def test_test_execution_output_dictionary_with_test_plan_id(testcase, date_time_
             },
             'tests': [
                 {
-                    'comment': 'Test',
+                    'comment': '{noformat:borderWidth=0px|bgColor=transparent}Test{noformat}',
                     'status': 'PASS',
                     'testKey': 'JIRA-1'
                 }
@@ -87,7 +87,7 @@ def test_test_execution_output_dictionary_with_test_execution_id(testcase, date_
             },
             'tests': [
                 {
-                    'comment': 'Test',
+                    'comment': '{noformat:borderWidth=0px|bgColor=transparent}Test{noformat}',
                     'status': 'PASS',
                     'testKey': 'JIRA-1'
                 }
@@ -122,7 +122,7 @@ def test_test_execution_full_model(testcase, date_time_now):
             },
             'tests': [
                 {
-                    'comment': 'Test',
+                    'comment': '{noformat:borderWidth=0px|bgColor=transparent}Test{noformat}',
                     'status': 'PASS',
                     'testKey': 'JIRA-1'
                 }
@@ -157,7 +157,7 @@ def test_test_execution_environ_model(testcase, date_time_now):
             },
             'tests': [
                 {
-                    'comment': 'Test',
+                    'comment': '{noformat:borderWidth=0px|bgColor=transparent}Test{noformat}',
                     'status': 'PASS',
                     'testKey': 'JIRA-1'
                 }

--- a/tests/test_xray_plugin.py
+++ b/tests/test_xray_plugin.py
@@ -410,12 +410,13 @@ def test_add_captures(testdir):
     expected_tests = [
         {'testKey': 'JIRA-1',
          'status': 'PASS',
-         'comment': '\n----------------------------- Captured stdout call -----------------------------\n'
+         'comment': '{noformat:borderWidth=0px|bgColor=transparent}'
+            '\n----------------------------- Captured stdout call -----------------------------\n'
             'to stdout\n'
             '----------------------------- Captured stderr call -----------------------------\n'
             'to stderr\n'
             '------------------------------ Captured log call -------------------------------\n'
-            'WARNING  root:test_add_captures.py:10 to logger'}
+            'WARNING  root:test_add_captures.py:10 to logger{noformat}'}
         ]
 
     result = testdir.runpytest(

--- a/tests/test_xray_plugin.py
+++ b/tests/test_xray_plugin.py
@@ -112,9 +112,10 @@ def test_if_user_can_modify_results_with_hooks(xray_tests):
     assert xray_result['info']['user'] == 'Test User'
 
 
-def test_if_user_can_attache_evidences(xray_tests):
+def test_if_user_can_attach_evidences(xray_tests):
     expected_tests = [
-        {'evidences': [
+        {'comment': '{noformat:borderWidth=0px|bgColor=transparent}Test{noformat}',
+         'evidences': [
              {
                  'contentType': 'plain/text',
                  'data': 'ZXZpZGVuY2U=',
@@ -168,6 +169,7 @@ def test_if_user_can_attache_evidences(xray_tests):
         def pytest_runtest_makereport(item, call):
             outcome = yield
             report = outcome.get_result()
+            report.longrepr = "Test"
             evidences = getattr(report, "evidences", [])
             if report.when == "call":
                 evidences.append(

--- a/tests/test_xray_plugin.py
+++ b/tests/test_xray_plugin.py
@@ -114,8 +114,7 @@ def test_if_user_can_modify_results_with_hooks(xray_tests):
 
 def test_if_user_can_attache_evidences(xray_tests):
     expected_tests = [
-        {'comment': '',
-         'evidences': [
+        {'evidences': [
              {
                  'contentType': 'plain/text',
                  'data': 'ZXZpZGVuY2U=',
@@ -411,7 +410,7 @@ def test_add_captures(testdir):
         {'testKey': 'JIRA-1',
          'status': 'PASS',
          'comment': '{noformat:borderWidth=0px|bgColor=transparent}'
-            '\n----------------------------- Captured stdout call -----------------------------\n'
+            '----------------------------- Captured stdout call -----------------------------\n'
             'to stdout\n'
             '----------------------------- Captured stderr call -----------------------------\n'
             'to stderr\n'


### PR DESCRIPTION
Hello,

This is a small patch to fix an issue with the --add-captures option, I have pushed recently. 
Captures are plain text paragraphs but the comment field of the Test Run, interprets and formats them in HTML. I have found that some code lines (printed on error) or output may be confusing with this formatting - e.g. '|' are interpreted as columns of a table.
The comment field can be formatted with a special notation: https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all

This PR fix it with the {noformat} notation for the content of the comment field which is then printed in monospace font in a <pre></pre> HTML section.
