### PR TITLE
Add default summary string

### DIFF
--- a/src/pytest_xray/helper.py
+++ b/src/pytest_xray/helper.py
@@ -19,6 +19,9 @@ from pytest_xray.constant import (
 from pytest_xray.exceptions import XrayError
 
 
+DEFAULT_SUMMARY_DESCRIPTION: str = 'Execution of automated tests'
+
+
 class Status(str, enum.Enum):
     TODO = 'TODO'
     EXECUTING = 'EXECUTING'
@@ -137,7 +140,11 @@ class TestExecution:
             constant.ENV_MULTI_VALUE_SPLIT_PATTERN
         )
         self.fix_version = fix_version or _first_from_environ(constant.ENV_TEST_EXECUTION_FIX_VERSION)
-        self.summary = summary or _from_environ_or_none(constant.ENV_TEST_EXECUTION_SUMMARY)
+        self.summary = (
+            summary
+            or _from_environ_or_none(constant.ENV_TEST_EXECUTION_SUMMARY)
+            or DEFAULT_SUMMARY_DESCRIPTION
+        )
         self.description = description or _from_environ_or_none(constant.ENV_TEST_EXECUTION_DESC)
 
     def append(self, test: Union[dict, TestCase]) -> None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -40,7 +40,8 @@ def test_test_execution_output_dictionary(testcase, date_time_now):
         assert te.as_dict() == {
             'info': {
                 'finishDate': '2021-04-23T16:30:02+0000',
-                'startDate': '2021-04-23T16:30:02+0000'
+                'startDate': '2021-04-23T16:30:02+0000',
+                'summary': 'Execution of automated tests'
             },
             'tests': [
                 {
@@ -61,7 +62,8 @@ def test_test_execution_output_dictionary_with_test_plan_id(testcase, date_time_
             'info': {
                 'finishDate': '2021-04-23T16:30:02+0000',
                 'startDate': '2021-04-23T16:30:02+0000',
-                'testPlanKey': 'Jira-10'
+                'testPlanKey': 'Jira-10',
+                'summary': 'Execution of automated tests'
             },
             'tests': [
                 {
@@ -83,7 +85,8 @@ def test_test_execution_output_dictionary_with_test_execution_id(testcase, date_
             'info': {
                 'finishDate': '2021-04-23T16:30:02+0000',
                 'startDate': '2021-04-23T16:30:02+0000',
-                'testPlanKey': 'Jira-10'
+                'testPlanKey': 'Jira-10',
+                'summary': 'Execution of automated tests'
             },
             'tests': [
                 {
@@ -149,6 +152,7 @@ def test_test_execution_environ_model(testcase, date_time_now):
                 'startDate': '2021-04-23T16:30:02+0000',
                 'testPlanKey': 'Jira-10',
                 'version': '1.1',
+                'summary': 'Execution of automated tests',
                 'testEnvironments': [
                     'MyLocalLaptop',
                     'And',


### PR DESCRIPTION
Field `summary` is mandatory for Xray, so it must be set with default value when it is not provided by a user.