### PR TITLE
Add support for marking tests with defects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ Tests can be marked with defects, which will be part of the data uploaded to Xra
     def test_with_defects():
         assert True
 
-Note that defects are always present in the data uploaded to Xray, regardless of the test outcome. 
+Note that defects are always present in the data uploaded to Xray, regardless of the test outcome.
 
 Attach test evidences
 +++++++++++++++++++++

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Jira Xray configuration can be provided via Environment Variables:
 
 .. code-block:: bash
 
-    $ export XRAY_API_USER=<jria username>
+    $ export XRAY_API_USER=<jira username>
     $ export XRAY_API_PASSWORD=<user password>
 
 * Personal Access Token authentication (``--api-key-auth`` option)
@@ -235,6 +235,25 @@ the following rules:
 - The status will be the intuitive combination of the individual results: if ``test_my_process_1``
   is a ``PASS`` but ``test_my_process_2`` is a ``FAIL``, ``JIRA-1`` will be marked as ``FAIL``.
 
+Defects support
++++++++++++++++
+
+Tests can be marked with defects, which will be part of the data uploaded to Xray:
+
+.. code-block:: python
+
+    # -- FILE: test_example.py
+
+    import pytest
+
+    @pytest.mark.xray(
+        'JIRA-1',
+        defects=['BUG-1', 'BUG-2']
+    )
+    def test_with_defects():
+        assert True
+
+Note that defects are always present in the data uploaded to Xray, regardless of the test outcome. 
 
 Attach test evidences
 +++++++++++++++++++++

--- a/src/pytest_xray/helper.py
+++ b/src/pytest_xray/helper.py
@@ -70,13 +70,15 @@ class TestCase:
         status: Status,
         comment: Optional[str] = None,
         status_str_mapper: Optional[Dict[Status, str]] = None,
-        evidences: Optional[List[Dict[str, str]]] = None
+        evidences: Optional[List[Dict[str, str]]] = None,
+        defects: Optional[List[str]] = None,
     ) -> None:
         self.test_key = test_key
         self.status = status
         self.comment = comment or ''
         self.status_str_mapper = status_str_mapper or STATUS_STR_MAPPER_JIRA
         self.evidences = evidences or []
+        self.defects = defects or []
 
     def merge(self, other: 'TestCase') -> None:
         """
@@ -102,6 +104,10 @@ class TestCase:
 
         self.status = _merge_status(self.status, other.status)
 
+        for defect in other.defects:
+            if defect not in self.defects:
+                self.defects.append(defect)
+
     def as_dict(self) -> Dict[str, Any]:
         data: Dict[str, Any] = dict(
             testKey=self.test_key,
@@ -111,6 +117,8 @@ class TestCase:
             data['comment'] = '{noformat:borderWidth=0px|bgColor=transparent}' + self.comment + '{noformat}'
         if self.evidences:
             data['evidences'] = self.evidences
+        if self.defects:
+            data['defects'] = self.defects
         return data
 
 

--- a/src/pytest_xray/xray_plugin.py
+++ b/src/pytest_xray/xray_plugin.py
@@ -67,11 +67,6 @@ class XrayPlugin:
         if not marker:
             return test_keys
 
-        if len(marker.kwargs) > 0:
-            raise XrayError(
-                'pytest.mark.xray does not accept any keyword arguments, '
-                f'the test {item.nodeid} does not seem to be decorated in proper way.'
-            )
         if len(marker.args) == 0:
             raise XrayError(
                 'pytest.mark.xray needs at least one argument, '
@@ -84,6 +79,20 @@ class XrayPlugin:
         else:
             raise XrayError(f'xray marker can only accept strings or lists but got {type(marker.args[0])}')
         return test_keys
+
+    def _get_defects(self, item: Item) -> List[str]:
+        """Return JIRA ids for defects associated with test item"""
+        marker = self._get_xray_marker(item)
+
+        if not marker:
+            return []
+        
+        defects = marker.kwargs.get('defects', [])
+
+        if isinstance(defects, list):
+            return defects
+        
+        raise XrayError(f'xray marker can only accept list of defects but got {type(defects)}')
 
     def _verify_jira_ids_for_items(self, items: List[Item]) -> None:
         """Verify duplicated jira ids."""
@@ -115,11 +124,18 @@ class XrayPlugin:
     def pytest_runtest_makereport(self, item, call):
         outcome = yield
         report = outcome.get_result()
+
         if not hasattr(report, 'test_keys'):
             report.test_keys = {}
         test_keys = self._get_test_keys(item)
         if test_keys and item.nodeid not in report.test_keys:
             report.test_keys[item.nodeid] = test_keys
+
+        if not hasattr(report, 'defects'):
+            report.defects = {}
+        defects = self._get_defects(item)
+        if defects and item.nodeid not in report.defects:
+            report.defects[item.nodeid] = defects
 
     def pytest_runtest_logreport(self, report: TestReport):
         status = self._get_status_from_report(report)
@@ -130,6 +146,7 @@ class XrayPlugin:
         if test_keys is None:
             return
 
+        defects = report.defects.get(report.nodeid)
         evidences = getattr(report, 'evidences', [])
 
         comment = report.longreprtext
@@ -151,7 +168,8 @@ class XrayPlugin:
                 status=status,
                 comment=comment,
                 status_str_mapper=self.status_str_mapper,
-                evidences=evidences
+                evidences=evidences,
+                defects=defects,
             )
             try:
                 test_case = self.test_execution.find_test_case(test_key)

--- a/src/pytest_xray/xray_plugin.py
+++ b/src/pytest_xray/xray_plugin.py
@@ -86,12 +86,12 @@ class XrayPlugin:
 
         if not marker:
             return []
-        
+
         defects = marker.kwargs.get('defects', [])
 
         if isinstance(defects, list):
             return defects
-        
+
         raise XrayError(f'xray marker can only accept list of defects but got {type(defects)}')
 
     def _verify_jira_ids_for_items(self, items: List[Item]) -> None:


### PR DESCRIPTION
This PR adds support for the [`defects` property in the Test Run details](https://docs.getxray.app/display/XRAY/Import+Execution+Results#ImportExecutionResults-%22tests%22object-TestRundetails), allowing users to mark tests with known defects:

```python
import pytest

@pytest.mark.xray('JIRA-1', defects=['BUG-1', 'BUG-2'])
def test_with_defects():
    assert True
```